### PR TITLE
Fix patient visit count query syntax

### DIFF
--- a/bend/app/Http/Controllers/API/ReportController.php
+++ b/bend/app/Http/Controllers/API/ReportController.php
@@ -65,7 +65,7 @@ class ReportController extends Controller
         // By service
         $byServiceRows = (clone $base)
             ->leftJoin('services as s', 's.id', '=', 'v.service_id')
-            ->selectRaw('v.service_id, COALESCE(s.name, \"(Unspecified)\") as service_name, COUNT(*) as count')
+            ->selectRaw("v.service_id, COALESCE(s.name, '(Unspecified)') as service_name, COUNT(*) as count")
             ->groupBy('v.service_id', 's.name')
             ->orderByDesc('count')
             ->get();


### PR DESCRIPTION
Fix SQL syntax error in `COALESCE` statement by changing double quotes to single quotes for string literal.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1a0c072-0969-47f5-b6e4-cdbd7a77bd7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c1a0c072-0969-47f5-b6e4-cdbd7a77bd7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

